### PR TITLE
Address Pratyush's comments for #425 in VariableBaseMSM.

### DIFF
--- a/ec/src/models/short_weierstrass_jacobian.rs
+++ b/ec/src/models/short_weierstrass_jacobian.rs
@@ -172,7 +172,7 @@ impl<P: Parameters> Add<Self> for GroupAffine<P> {
 impl<'a, P: Parameters> AddAssign<&'a Self> for GroupAffine<P> {
     fn add_assign(&mut self, other: &'a Self) {
         let mut s_proj = GroupProjective::from(*self);
-        ProjectiveCurve::add_assign_mixed(&mut s_proj, other);
+        s_proj.add_assign_mixed(other);
         *self = s_proj.into();
     }
 }
@@ -563,7 +563,7 @@ impl<P: Parameters> ProjectiveCurve for GroupProjective<P> {
 
         if self.x == u2 && self.y == s2 {
             // The two points are equal, so we double.
-            ProjectiveCurve::double_in_place(self);
+            self.double_in_place();
         } else {
             // If we're adding -a and a together, self.z becomes zero as H becomes zero.
 
@@ -672,7 +672,7 @@ impl<'a, P: Parameters> AddAssign<&'a Self> for GroupProjective<P> {
 
         if u1 == u2 && s1 == s2 {
             // The two points are equal, so we double.
-            ProjectiveCurve::double_in_place(self);
+            self.double_in_place();
         } else {
             // If we're adding -a and a together, self.z becomes zero as H becomes zero.
 
@@ -919,11 +919,13 @@ impl<P: Parameters> VariableBaseMSM for GroupProjective<P> {
 
     type Scalar = <Self as ProjectiveCurve>::ScalarField;
 
-    fn double_in_place(&mut self) -> &mut Self {
-        ProjectiveCurve::double_in_place(self)
+    #[inline]
+    fn _double_in_place(&mut self) -> &mut Self {
+        self.double_in_place()
     }
 
-    fn add_assign_mixed(&mut self, other: &Self::MSMBase) {
-        ProjectiveCurve::add_assign_mixed(self, other)
+    #[inline]
+    fn _add_assign_mixed(&mut self, other: &Self::MSMBase) {
+        self.add_assign_mixed(other)
     }
 }

--- a/ec/src/msm/variable_base/mod.rs
+++ b/ec/src/msm/variable_base/mod.rs
@@ -28,9 +28,11 @@ pub trait VariableBaseMSM:
 
     type Scalar: PrimeField;
 
-    fn double_in_place(&mut self) -> &mut Self;
+    #[doc(hidden)]
+    fn _double_in_place(&mut self) -> &mut Self;
 
-    fn add_assign_mixed(&mut self, other: &Self::MSMBase);
+    #[doc(hidden)]
+    fn _add_assign_mixed(&mut self, other: &Self::MSMBase);
 
     /// Optimized implementation of multi-scalar multiplication.
     ///
@@ -98,7 +100,7 @@ pub trait VariableBaseMSM:
                     if scalar == fr_one {
                         // We only process unit scalars once in the first window.
                         if w_start == 0 {
-                            res.add_assign_mixed(base);
+                            res._add_assign_mixed(base);
                         }
                     } else {
                         let mut scalar = scalar;
@@ -114,7 +116,7 @@ pub trait VariableBaseMSM:
                         // bucket.
                         // (Recall that `buckets` doesn't have a zero bucket.)
                         if scalar != 0 {
-                            buckets[(scalar - 1) as usize].add_assign_mixed(base);
+                            buckets[(scalar - 1) as usize]._add_assign_mixed(base);
                         }
                     }
                 });
@@ -153,7 +155,7 @@ pub trait VariableBaseMSM:
                 .fold(zero, |mut total, sum_i| {
                     total += sum_i;
                     for _ in 0..c {
-                        total.double_in_place();
+                        total._double_in_place();
                     }
                     total
                 })


### PR DESCRIPTION
Prefix `add_assign_mixed` and `double_in_place` with underscore and
hide from documentation.